### PR TITLE
Const generics have been added to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitarray"
-version = "0.2.6"
+version = "0.3.0"
 edition = "2018"
 authors = ["Geordon Worley <vadixidav@gmail.com>"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A compile time sized array of bits that uses const generics and intrinsics.
 This library was created to maximize the speed of hamming weight and hamming distance computation.
 It could be used for many other things. Contributions are welcome!
 
+The minimum supported rustc version is 1.51
+
 ## Features
 
 Enable the `unstable-512-bit-simd` feature if you would like to use 512-bit SIMD instructions to speed up the library. This feature does not compile on all machines for some currently unknown reason, as an LLVM intrinsics error is reported, even with the same compiler version and host tripple.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![feature(min_const_generics)]
 #![cfg_attr(
     feature = "unstable-512-bit-simd",
     feature(link_llvm_intrinsics, repr_simd, simd_ffi, platform_intrinsics)


### PR DESCRIPTION
Const Generics have been added to stable rust since 1.51, so update the crate so it doesnt need nightly rust to build. Indicate a breaking change for people running older rustc